### PR TITLE
Update routine prompt examples with duration metadata

### DIFF
--- a/assets/prompts/diet_get_routine.txt
+++ b/assets/prompts/diet_get_routine.txt
@@ -34,6 +34,8 @@ EXEMPLO 1 (semana normal + fds livre):
     "name": "Dieta Semanal com 2 livres",
     "description": "Semana padrão com 2 refeições livres distribuídas no fim de semana.",
     "repetition_schema": "Semanal",
+    "target_duration_days": null,
+    "end_date": null,
     "block_sequence_placeholders": ["semana_com_fds_livre"]
   },
   "blocks_to_create": [
@@ -48,6 +50,8 @@ EXEMPLO 2 (ciclo 10/4 déficit/manutenção):
     "name": "Ciclo 10/4 Déficit-Manutenção",
     "description": "10 dias em déficit, 4 dias em manutenção.",
     "repetition_schema": "Quinzenal",
+    "target_duration_days": 84,
+    "end_date": "2024-11-15",
     "block_sequence_placeholders": ["dez_deficit_quatro_manutencao"]
   },
   "blocks_to_create": [

--- a/assets/prompts/planner_get_routine.txt
+++ b/assets/prompts/planner_get_routine.txt
@@ -37,6 +37,8 @@ EXEMPLO 1 (PPL 6x com descanso):
     "name": "PPL 6x com descanso",
     "description": "Push/Pull/Legs repetido em 6 dias seguidos + 1 descanso.",
     "repetition_schema": "Semanal",
+    "target_duration_days": null,
+    "end_date": null,
     "block_sequence_placeholders": ["ppl_semanal"]
   },
   "blocks_to_create": [
@@ -51,6 +53,8 @@ EXEMPLO 2 (Upper/Lower 4x com 3 descansos):
     "name": "Upper/Lower 4x",
     "description": "Duas sessões de Upper e duas de Lower por semana, com 3 dias leve/descanso.",
     "repetition_schema": "Semanal",
+    "target_duration_days": 84,
+    "end_date": "2024-09-30",
     "block_sequence_placeholders": ["upper_lower_semana"]
   },
   "blocks_to_create": [


### PR DESCRIPTION
## Summary
- add explicit target_duration_days and end_date fields to planner routine examples
- add explicit target_duration_days and end_date fields to diet routine examples

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d71ade6aa08325a387fbff41a19f5d