### PR TITLE
Refine planner prompts and LLM client

### DIFF
--- a/assets/prompts/planner_get_block_structure.txt
+++ b/assets/prompts/planner_get_block_structure.txt
@@ -12,7 +12,7 @@ REGRAS:
   maior frequência/volume para os músculos de foco (ex.: costas/braços 2x, peito/pernas 1x).
 - Saída estrita em JSON, sem texto extra.
 
-FORMATO:
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "block_id": "placeholder_id",
   "days_to_create": [
@@ -80,4 +80,13 @@ EXEMPLO 4 (Block Quinzenal focado em Costas e Braços mantendo corpo todo):
     { "placeholder_id": "descanso3", "name": "Descanso", "description": "Sono e alongamentos leves.", "is_rest": true }
   ],
   "reuse_days_by_name": []
+}
+
+EXEMPLO 5 (Reutilizando dia existente):
+{
+  "block_id": "upper_lower_focus_back_arms",
+  "days_to_create": [
+    { "placeholder_id": "upper_back_arms_b", "name": "Upper Costas/Braços B", "description": "Costas largura + braços em variações.", "is_rest": false }
+  ],
+  "reuse_days_by_name": ["Upper Costas/Braços A"]
 }

--- a/assets/prompts/planner_get_exercise.txt
+++ b/assets/prompts/planner_get_exercise.txt
@@ -11,7 +11,7 @@ REGRAS:
 - "relevant_metrics" deve ser subconjunto de: ["Peso","Repetições","Distância","Tempo","Séries","DescansoSeg"].
 - Textos curtos, objetivos, em PT-BR.
 
-FORMATO:
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "name": "string",
   "description": "string",
@@ -24,8 +24,8 @@ EXEMPLO 1 (força):
 {
   "name": "Agachamento Livre",
   "description": "Agachar abaixo dos 90°, tronco estável.",
-  "primary_muscles": ["quadríceps"],
-  "secondary_muscles": ["glúteos","lombar"],
+  "primary_muscles": ["quadriceps"],
+  "secondary_muscles": ["glutes","lower_back"],
   "relevant_metrics": ["Peso","Repetições","Séries","DescansoSeg"]
 }
 
@@ -33,7 +33,7 @@ EXEMPLO 2 (cardio):
 {
   "name": "Corrida em Esteira",
   "description": "Ritmo contínuo, postura ereta.",
-  "primary_muscles": ["quadríceps"],
-  "secondary_muscles": ["posterior_coxa","glúteos"],
+  "primary_muscles": ["quadriceps"],
+  "secondary_muscles": ["hamstrings","glutes"],
   "relevant_metrics": ["Tempo","Distância"]
 }

--- a/assets/prompts/planner_get_questions.txt
+++ b/assets/prompts/planner_get_questions.txt
@@ -19,7 +19,7 @@ ENTRADAS:
 - Perfil do Usuário: {user_profile}
 - Objetivo Principal: "{user_goal}"
 
-FORMATO:
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "questions": [
     { "id": "q1", "text": "..." },

--- a/assets/prompts/planner_get_routine.txt
+++ b/assets/prompts/planner_get_routine.txt
@@ -38,7 +38,7 @@ PASSOS OBRIGATÓRIOS:
 5. Se algum block já existir com o mesmo propósito, adicione-o em "reuse_blocks_by_name" em vez de duplicar.
 
 
-FORMATO:
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "routine": {
     "name": "string",
@@ -161,4 +161,24 @@ EXEMPLO 4 (Base → Pico para prova):
     }
   ],
   "reuse_blocks_by_name": []
+}
+
+EXEMPLO 5 (Reutilizando block existente):
+{
+  "routine": {
+    "name": "Rotina com Block Pré-existente",
+    "description": "Mantém o block de força do banco e adiciona block novo de condicionamento.",
+    "repetition_schema": "Semanal",
+    "target_duration_days": null,
+    "end_date": null,
+    "block_sequence_placeholders": ["forca_base_banco", "novo_conditioning"]
+  },
+  "blocks_to_create": [
+    {
+      "placeholder_id": "novo_conditioning",
+      "name": "Conditioning Semanal",
+      "description": "Dois dias de HIIT, um dia de circuito total e duas sessões leves de mobilidade/cardio." 
+    }
+  ],
+  "reuse_blocks_by_name": ["Block Força Base"]
 }

--- a/assets/prompts/planner_get_session_structure.txt
+++ b/assets/prompts/planner_get_session_structure.txt
@@ -19,7 +19,7 @@ REGRAS:
 - relevant_metrics deve ser subconjunto de: ["Peso","Repetições","Distância","Tempo","Séries","DescansoSeg"].
 - Textos curtos, objetivos, em PT-BR.
 
-FORMATO:
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "day_id": "string",
   "sessions_to_create": [
@@ -201,8 +201,8 @@ EXEMPLO 3 (Day Cutting Condicionamento)
         {
           "name": "Prancha com Alcance",
           "description": "3x40 s para core anti-rotação.",
-          "primary_muscles": ["core"],
-          "secondary_muscles": ["shoulders"],
+          "primary_muscles": ["abs"],
+          "secondary_muscles": ["obliques","lower_back"],
           "relevant_metrics": ["Tempo","Séries"]
         }
       ],
@@ -212,7 +212,29 @@ EXEMPLO 3 (Day Cutting Condicionamento)
   "reuse_sessions_by_name": []
 }
 
-EXEMPLO 4 (Day Upper focado em Costas/Braços mantendo equilíbrio):
+EXEMPLO 4 (Reutilizando sessão existente):
+{
+  "day_id": "upper_back_focus",
+  "sessions_to_create": [
+    {
+      "name": "Finalização Cardio",
+      "description": "HIIT curto para elevar VO2 sem comprometer recuperação.",
+      "exercises_to_create": [
+        {
+          "name": "Bike Ergométrica Sprint",
+          "description": "8 tiros de 30 s / 30 s descanso ativo.",
+          "primary_muscles": ["quadriceps"],
+          "secondary_muscles": ["glutes","calves"],
+          "relevant_metrics": ["Tempo","Distância"]
+        }
+      ],
+      "reuse_exercises_by_name": []
+    }
+  ],
+  "reuse_sessions_by_name": ["Upper Força Principal"]
+}
+
+EXEMPLO 5 (Day Upper focado em Costas/Braços mantendo equilíbrio):
 {
   "day_id": "upper_back_arms_a",
   "sessions_to_create": [
@@ -265,7 +287,7 @@ EXEMPLO 4 (Day Upper focado em Costas/Braços mantendo equilíbrio):
         {
           "name": "Face Pull na Polia",
           "description": "3x15 para estabilizadores de ombro.",
-          "primary_muscles": ["rear_deltoid"],
+          "primary_muscles": ["posterior_deltoid"],
           "secondary_muscles": ["upper_back"],
           "relevant_metrics": ["Peso","Repetições","Séries","DescansoSeg"]
         }

--- a/assets/prompts/planner_get_summary.txt
+++ b/assets/prompts/planner_get_summary.txt
@@ -24,7 +24,7 @@ REGRAS DE REDAÇÃO (PT-BR):
 - **Não** use listas com marcadores; escreva em parágrafos corridos.
 - **Não** inclua nada fora do JSON final.
 
-FORMATO DE SAÍDA (ESTRITO):
+FORMATO PRINCIPAL (JSON ÚNICO):
 {
   "workout_summary": "string",
   "nutrition_summary": "string"

--- a/lib/features/3_planner/infrastructure/llm/llm_client_impl.dart
+++ b/lib/features/3_planner/infrastructure/llm/llm_client_impl.dart
@@ -1,5 +1,6 @@
 // lib/features/3_planner/infrastructure/llm/llm_client_impl.dart
 import 'dart:convert';
+import 'dart:typed_data';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:fitapp/core/services/llm_service.dart';
 import 'package:fitapp/core/utils/json_safety.dart';
@@ -23,7 +24,23 @@ class LLMClientImpl {
     // ignore: avoid_print
     print('\n===== LLM PROMPT [$assetPath] =====\n$prompt\n====================================\n');
 
-    final resp = await _llm.getJson(prompt);
+    List<Uint8List>? imageBytes;
+    if (imagesBase64 != null && imagesBase64.isNotEmpty) {
+      final cleaned = imagesBase64.where((s) => s.trim().isNotEmpty);
+      final bytes = <Uint8List>[];
+      for (final base64 in cleaned) {
+        try {
+          bytes.add(base64Decode(base64));
+        } catch (_) {
+          // Ignore imagens inválidas; o LLM receberá apenas as válidas.
+        }
+      }
+      if (bytes.isNotEmpty) {
+        imageBytes = bytes;
+      }
+    }
+
+    final resp = await _llm.getJson(prompt, images: imageBytes);
 
     // LOG: resposta crua
     // ignore: avoid_print


### PR DESCRIPTION
## Summary
- clarify the planner prompt formats and add reuse-focused examples using JSON-only outputs
- fix exercise prompt examples to rely on valid muscle identifiers expected by the planner
- allow the planner LLM client to forward optional base64 images after decoding them safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d960b7f8c0832585811761a668381b